### PR TITLE
Rabbitmq 3.4.1

### DIFF
--- a/RabbitMQ/rabbitmq.nuspec
+++ b/RabbitMQ/rabbitmq.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>rabbitmq</id>
     <title>RabbitMQ</title>
-    <version>3.3.0.0</version>
+    <version>3.4.1.0</version>
     <authors>GoPivotal</authors>
     <owners>Scott Smerchek</owners>
     <summary>RabbitMQ - Messaging that just works</summary>
@@ -19,8 +19,8 @@
     </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>
-	<files>
+  <files>
     <file src="tools\**" target="tools" />
     <!--<file src="content\**" target="content" />-->
-	</files>
+  </files>
 </package>

--- a/RabbitMQ/tools/SetupRabbitMqManagement.bat
+++ b/RabbitMQ/tools/SetupRabbitMqManagement.bat
@@ -1,4 +1,4 @@
-call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.3.0\sbin\rabbitmq-service.bat" stop
-call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.3.0\sbin\rabbitmq-plugins.bat" enable rabbitmq_management
-call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.3.0\sbin\rabbitmq-service.bat" install
-call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.3.0\sbin\rabbitmq-service.bat" start
+call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.4.1\sbin\rabbitmq-service.bat" stop
+call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.4.1\sbin\rabbitmq-plugins.bat" enable rabbitmq_management
+call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.4.1\sbin\rabbitmq-service.bat" install
+call "C:\Program Files (x86)\RabbitMQ Server\rabbitmq_server-3.4.1\sbin\rabbitmq-service.bat" start

--- a/RabbitMQ/tools/chocolateyInstall.ps1
+++ b/RabbitMQ/tools/chocolateyInstall.ps1
@@ -3,7 +3,10 @@ try {
 
 	Install-ChocolateyPackage 'rabbitmq' 'EXE' '/S' 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.4.1/rabbitmq-server-3.4.1.exe' -validExitCodes @(0)
 
-	Start-ChocolateyProcessAsAdmin 'C:\Chocolatey\lib\rabbitmq.3.4.1.0\tools\SetupRabbitMqManagement.bat'
+	$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+	$target = Join-Path $scriptPath "SetupRabbitMqManagement.bat"
+
+	Start-ChocolateyProcessAsAdmin $target
 				    
   echo ""
   echo "RabbitMQ Management Plugin enabled by default at http://localhost:15672"

--- a/RabbitMQ/tools/chocolateyInstall.ps1
+++ b/RabbitMQ/tools/chocolateyInstall.ps1
@@ -1,9 +1,9 @@
 ﻿
 try {
 
-	Install-ChocolateyPackage 'rabbitmq' 'EXE' '/S' 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.3.0/rabbitmq-server-3.3.0.exe' -validExitCodes @(0)
+	Install-ChocolateyPackage 'rabbitmq' 'EXE' '/S' 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.4.1/rabbitmq-server-3.4.1.exe' -validExitCodes @(0)
 
-	Start-ChocolateyProcessAsAdmin 'C:\Chocolatey\lib\rabbitmq.3.3.0.0\tools\SetupRabbitMqManagement.bat'
+	Start-ChocolateyProcessAsAdmin 'C:\Chocolatey\lib\rabbitmq.3.4.1.0\tools\SetupRabbitMqManagement.bat'
 				    
   echo ""
   echo "RabbitMQ Management Plugin enabled by default at http://localhost:15672"


### PR DESCRIPTION
Updating to RabbitMQ 3.4.1
Calculate path to SetupRabbitMqManagement.bat sript in chocolateyInstall.ps1script - chocolate since 0.9.8.24 version use "C:\ProgramData\chocolatey" folder for install instead "C:\Chocolatey" by default
